### PR TITLE
Enable TLS certificate verification for registry connections (v2.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,82 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [v2.1.0] - 2026-02-22
+
+### Security
+
+- **TLS certificate verification is now enabled by default for registry connections.**
+  Previously, watchtower silently disabled TLS verification (`InsecureSkipVerify`) for
+  all registry digest checks, exposing registry credentials to potential man-in-the-middle
+  attacks on the network path between watchtower and the registry.
+
+### Added
+
+- `--no-tls-verify` flag (`WATCHTOWER_NO_TLS_VERIFY=true`) to opt out of TLS certificate
+  verification for registry connections. This replaces the previous unconditional insecure
+  behaviour and is intended only for private/self-hosted registries using self-signed
+  certificates.
+
+### Migration guide for self-hosted registry users
+
+If you run watchtower against a private registry with a **self-signed or internally-signed
+TLS certificate**, you must now explicitly pass `--no-tls-verify` (or set the environment
+variable `WATCHTOWER_NO_TLS_VERIFY=true`). Without it, watchtower will fail to verify the
+registry's certificate and fall back to a full image pull for every check cycle.
+
+**Docker CLI / Docker Compose:**
+
+```yaml
+services:
+  watchtower:
+    image: ghcr.io/apivzero/watchtower
+    environment:
+      - WATCHTOWER_NO_TLS_VERIFY=true
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+```
+
+**Command line:**
+
+```sh
+docker run ghcr.io/apivzero/watchtower --no-tls-verify
+```
+
+If you are unsure whether your registry uses a self-signed certificate, watchtower will now
+log a clear warning when a certificate error is detected:
+
+```
+WARN Could not do a head request for "registry.internal/myimage:latest", falling back to regular pull.
+WARN Reason: tls: failed to verify certificate: x509: certificate signed by unknown authority
+WARN If "registry.internal/myimage:latest" uses a self-signed certificate, set --no-tls-verify (env: WATCHTOWER_NO_TLS_VERIFY=true) to disable certificate verification.
+```
+
+Users connecting to public registries (Docker Hub, GHCR, ECR, GCR, etc.) are unaffected —
+those registries use trusted certificates and no configuration change is needed.
+
+---
+
+## [v2.0.1] - 2025-01-17
+
+### Fixed
+
+- Fix arm64 platform string in goreleaser `dockers_v2` config.
+- Fix Dockerfile for goreleaser `dockers_v2` build context.
+
+---
+
+## [v2.0.0] - 2025-01-17
+
+Initial release of the `apivzero/watchtower` fork from the archived
+`containrrr/watchtower`. See the [migration guide](docs/migration.md) for
+details on upgrading from `containrrr/watchtower`.
+
+### Changed
+
+- Module path changed to `github.com/apivzero/watchtower`.
+- Container images published to GHCR only (`ghcr.io/apivzero/watchtower`).
+- Upgraded Docker SDK to v27.5.1 with API version negotiation for Docker 28+ compatibility.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -112,6 +112,7 @@ func PreRun(cmd *cobra.Command, _ []string) {
 	}
 
 	noPull, _ = f.GetBool("no-pull")
+	noTLSVerify, _ := f.GetBool("no-tls-verify")
 	includeStopped, _ := f.GetBool("include-stopped")
 	includeRestarting, _ := f.GetBool("include-restarting")
 	reviveStopped, _ := f.GetBool("revive-stopped")
@@ -128,6 +129,7 @@ func PreRun(cmd *cobra.Command, _ []string) {
 		RemoveVolumes:     removeVolumes,
 		IncludeRestarting: includeRestarting,
 		WarnOnHeadFailed:  container.WarningStrategy(warnOnHeadPullFailed),
+		NoTLSVerify:       noTLSVerify,
 	})
 
 	notifier = notifications.NewNotifier(cmd)

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -425,6 +425,24 @@ Environment Variable: DOCKER_TLS_VERIFY
              Default: false
 ```
 
+## Disable registry TLS verification
+
+Disable TLS certificate verification when connecting to registries for digest checks. By default,
+watchtower verifies the registry's certificate chain and host name. Use this option only with
+private or self-hosted registries that use self-signed or internally-signed certificates.
+
+!!! warning
+    Disabling TLS verification exposes registry credentials to potential interception. Only use
+    this option when connecting to a registry whose certificate cannot be added to the system
+    trust store.
+
+```text
+            Argument: --no-tls-verify
+Environment Variable: WATCHTOWER_NO_TLS_VERIFY
+                Type: Boolean
+             Default: false
+```
+
 ## HEAD failure warnings
 
 When to warn about HEAD pull requests failing. Auto means that it will warn when the registry is known to handle the

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -57,6 +57,12 @@ func RegisterSystemFlags(rootCmd *cobra.Command) {
 		"Do not pull any new images")
 
 	flags.BoolP(
+		"no-tls-verify",
+		"",
+		envBool("WATCHTOWER_NO_TLS_VERIFY"),
+		"Disable TLS certificate verification when connecting to registries. Use only with private registries using self-signed certificates.")
+
+	flags.BoolP(
 		"no-restart",
 		"",
 		envBool("WATCHTOWER_NO_RESTART"),

--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -3,6 +3,9 @@ package container
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -65,6 +68,7 @@ type ClientOptions struct {
 	ReviveStopped     bool
 	IncludeRestarting bool
 	WarnOnHeadFailed  WarningStrategy
+	NoTLSVerify       bool
 }
 
 // WarningStrategy is a value determining when to show warnings
@@ -377,13 +381,16 @@ func (client dockerClient) PullImage(ctx context.Context, container t.Container)
 
 	log.WithFields(fields).Debugf("Checking if pull is needed")
 
-	if match, err := digest.CompareDigest(container, opts.RegistryAuth); err != nil {
+	if match, err := digest.CompareDigest(container, opts.RegistryAuth, client.NoTLSVerify); err != nil {
 		headLevel := log.DebugLevel
 		if client.WarnOnHeadPullFailed(container) {
 			headLevel = log.WarnLevel
 		}
 		log.WithFields(fields).Logf(headLevel, "Could not do a head request for %q, falling back to regular pull.", imageName)
 		log.WithFields(fields).Log(headLevel, "Reason: ", err)
+		if !client.NoTLSVerify && isCertError(err) {
+			log.WithFields(fields).Warnf("If %q uses a self-signed certificate, set --no-tls-verify (env: WATCHTOWER_NO_TLS_VERIFY=true) to disable certificate verification.", imageName)
+		}
 	} else if match {
 		log.Debug("No pull needed. Skipping image.")
 		return nil
@@ -558,4 +565,16 @@ func (client dockerClient) waitForStopOrTimeout(c t.Container, waitTime time.Dur
 		}
 		time.Sleep(1 * time.Second)
 	}
+}
+
+// isCertError reports whether err is a TLS certificate verification failure.
+func isCertError(err error) bool {
+	var tlsCertErr *tls.CertificateVerificationError
+	var unknownAuth x509.UnknownAuthorityError
+	var hostnameErr x509.HostnameError
+	var certInvalid x509.CertificateInvalidError
+	return errors.As(err, &tlsCertErr) ||
+		errors.As(err, &unknownAuth) ||
+		errors.As(err, &hostnameErr) ||
+		errors.As(err, &certInvalid)
 }

--- a/pkg/registry/auth/auth.go
+++ b/pkg/registry/auth/auth.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -19,7 +20,7 @@ import (
 const ChallengeHeader = "WWW-Authenticate"
 
 // GetToken fetches a token for the registry hosting the provided image
-func GetToken(container types.Container, registryAuth string) (string, error) {
+func GetToken(container types.Container, registryAuth string, noTLSVerify bool) (string, error) {
 	normalizedRef, err := ref.ParseNormalizedNamed(container.ImageName())
 	if err != nil {
 		return "", err
@@ -33,7 +34,7 @@ func GetToken(container types.Container, registryAuth string) (string, error) {
 		return "", err
 	}
 
-	client := &http.Client{}
+	client := newHTTPClient(noTLSVerify)
 	var res *http.Response
 	if res, err = client.Do(req); err != nil {
 		return "", err
@@ -55,7 +56,7 @@ func GetToken(container types.Container, registryAuth string) (string, error) {
 		return fmt.Sprintf("Basic %s", registryAuth), nil
 	}
 	if strings.HasPrefix(challenge, "bearer") {
-		return GetBearerHeader(challenge, normalizedRef, registryAuth)
+		return GetBearerHeader(challenge, normalizedRef, registryAuth, noTLSVerify)
 	}
 
 	return "", errors.New("unsupported challenge type from registry")
@@ -73,8 +74,8 @@ func GetChallengeRequest(URL url.URL) (*http.Request, error) {
 }
 
 // GetBearerHeader tries to fetch a bearer token from the registry based on the challenge instructions
-func GetBearerHeader(challenge string, imageRef ref.Named, registryAuth string) (string, error) {
-	client := http.Client{}
+func GetBearerHeader(challenge string, imageRef ref.Named, registryAuth string, noTLSVerify bool) (string, error) {
+	client := newHTTPClient(noTLSVerify)
 	authURL, err := GetAuthURL(challenge, imageRef)
 
 	if err != nil {
@@ -146,6 +147,19 @@ func GetAuthURL(challenge string, imageRef ref.Named) (*url.URL, error) {
 
 	authURL.RawQuery = q.Encode()
 	return authURL, nil
+}
+
+// newHTTPClient returns an HTTP client with TLS verification configured
+// according to noTLSVerify.
+func newHTTPClient(noTLSVerify bool) *http.Client {
+	if !noTLSVerify {
+		return &http.Client{}
+	}
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+		},
+	}
 }
 
 // GetChallengeURL returns the URL to check auth requirements

--- a/pkg/registry/auth/auth_test.go
+++ b/pkg/registry/auth/auth_test.go
@@ -58,7 +58,7 @@ var _ = Describe("the auth module", func() {
 		It("should parse the token from the response",
 			SkipIfCredentialsEmpty(GHCRCredentials, func() {
 				creds := fmt.Sprintf("%s:%s", GHCRCredentials.Username, GHCRCredentials.Password)
-				token, err := auth.GetToken(mockContainer, creds)
+				token, err := auth.GetToken(mockContainer, creds, false)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(token).NotTo(Equal(""))
 			}),

--- a/pkg/registry/digest/digest.go
+++ b/pkg/registry/digest/digest.go
@@ -22,7 +22,7 @@ import (
 const ContentDigestHeader = "Docker-Content-Digest"
 
 // CompareDigest ...
-func CompareDigest(container types.Container, registryAuth string) (bool, error) {
+func CompareDigest(container types.Container, registryAuth string, noTLSVerify bool) (bool, error) {
 	if !container.HasImageInfo() {
 		return false, errors.New("container image info missing")
 	}
@@ -30,7 +30,7 @@ func CompareDigest(container types.Container, registryAuth string) (bool, error)
 	var digest string
 
 	registryAuth = TransformAuth(registryAuth)
-	token, err := auth.GetToken(container, registryAuth)
+	token, err := auth.GetToken(container, registryAuth, noTLSVerify)
 	if err != nil {
 		return false, err
 	}
@@ -40,7 +40,7 @@ func CompareDigest(container types.Container, registryAuth string) (bool, error)
 		return false, err
 	}
 
-	if digest, err = GetDigest(digestURL, token); err != nil {
+	if digest, err = GetDigest(digestURL, token, noTLSVerify); err != nil {
 		return false, err
 	}
 
@@ -75,7 +75,7 @@ func TransformAuth(registryAuth string) string {
 }
 
 // GetDigest from registry using a HEAD request to prevent rate limiting
-func GetDigest(url string, token string) (string, error) {
+func GetDigest(url string, token string, noTLSVerify bool) (string, error) {
 	tr := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
@@ -87,7 +87,7 @@ func GetDigest(url string, token string) (string, error) {
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
-		TLSClientConfig:       &tls.Config{InsecureSkipVerify: true},
+		TLSClientConfig:       &tls.Config{InsecureSkipVerify: noTLSVerify}, //nolint:gosec
 	}
 	client := &http.Client{Transport: tr}
 

--- a/pkg/registry/digest/digest_test.go
+++ b/pkg/registry/digest/digest_test.go
@@ -65,7 +65,7 @@ var _ = Describe("Digests", func() {
 		It("should return true if digests match",
 			SkipIfCredentialsEmpty(GHCRCredentials, func() {
 				creds := fmt.Sprintf("%s:%s", GHCRCredentials.Username, GHCRCredentials.Password)
-				matches, err := digest.CompareDigest(mockContainer, creds)
+				matches, err := digest.CompareDigest(mockContainer, creds, false)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(matches).To(Equal(true))
 			}),
@@ -78,7 +78,7 @@ var _ = Describe("Digests", func() {
 
 		})
 		It("should return an error when container contains no image info", func() {
-			matches, err := digest.CompareDigest(mockContainerNoImage, `user:pass`)
+			matches, err := digest.CompareDigest(mockContainerNoImage, `user:pass`, false)
 			Expect(err).To(HaveOccurred())
 			Expect(matches).To(Equal(false))
 		})
@@ -116,7 +116,7 @@ var _ = Describe("Digests", func() {
 					}),
 				),
 			)
-			dig, err := digest.GetDigest(server.URL(), "token")
+			dig, err := digest.GetDigest(server.URL(), "token", false)
 			Expect(server.ReceivedRequests()).Should(HaveLen(1))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(dig).To(Equal(mockDigest))


### PR DESCRIPTION
## Summary

- TLS certificate verification is now **enabled by default** for all registry digest checks. Previously `InsecureSkipVerify` was hardcoded to `true`, silently exposing registry credentials to MITM attacks.
- New `--no-tls-verify` flag (`WATCHTOWER_NO_TLS_VERIFY=true`) allows users with self-hosted registries using self-signed certificates to opt out.
- When a certificate error is detected, watchtower now logs a `WARN` explicitly naming the flag so users know how to recover.

See `CHANGELOG.md` for the full migration guide.

## Breaking change

Users running watchtower against a **private registry with a self-signed or internally-signed certificate** must add `--no-tls-verify` / `WATCHTOWER_NO_TLS_VERIFY=true`. Users on public registries (Docker Hub, GHCR, ECR, GCR, etc.) are unaffected.

## Files changed

| File | Change |
|---|---|
| `pkg/registry/digest/digest.go` | `InsecureSkipVerify` now driven by `noTLSVerify` param (default `false`) |
| `pkg/container/client.go` | `NoTLSVerify` added to `ClientOptions`; x509 errors surface an actionable `WARN` |
| `internal/flags/flags.go` | `--no-tls-verify` / `WATCHTOWER_NO_TLS_VERIFY` registered |
| `cmd/root.go` | Flag read and passed into `ClientOptions` |
| `pkg/registry/digest/digest_test.go` | Test call sites updated for new signatures |
| `CHANGELOG.md` | Created with v2.1.0 entry, migration guide, and example warning output |

## Test plan

- [ ] CI passes (build, lint, test, CodeQL)
- [ ] Manually verify containers on a public registry still update normally
- [ ] Manually verify `--no-tls-verify` restores behaviour for self-signed cert registries

🤖 Generated with [Claude Code](https://claude.com/claude-code)